### PR TITLE
Add jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+mdsdToolsEclipsePipeline {  
+	webserverDir = 'characteristicsmodeling'
+	updateSiteLocation = 'releng/tools.mdsd.characteristics.updatesite/target/repository'
+} 

--- a/bundles/tools.mdsd.characteristics.model/META-INF/MANIFEST.MF
+++ b/bundles/tools.mdsd.characteristics.model/META-INF/MANIFEST.MF
@@ -30,8 +30,7 @@ Require-Bundle: org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.ocl.pivot;visibility:=reexport,
  org.eclipse.ocl.examples.codegen;visibility:=reexport,
  org.eclipse.core.runtime,
- tools.mdsd.modelingfoundations.identifier;bundle-version="0.1.0";visibility:=reexport,
- org.eclipse.emf.cdo;bundle-version="4.6.100";visibility:=reexport,
+ tools.mdsd.modelingfoundations.identifier;visibility:=reexport,
  tools.mdsd.characteristics.mwe2;resolution:=optional
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: tools.mdsd.characteristics.Activator

--- a/bundles/tools.mdsd.characteristics.thirdparty/META-INF/MANIFEST.MF
+++ b/bundles/tools.mdsd.characteristics.thirdparty/META-INF/MANIFEST.MF
@@ -12,4 +12,6 @@ Export-Package: com.google.inject;version="1.4",com.google.inject.bind
  nject.multibindings;version="1.4",com.google.inject.name;version="1.4
  ",com.google.inject.spi;version="1.4",com.google.inject.util;version=
  "1.4"
-Require-Bundle: javax.inject
+Import-Package: javax.inject;version="1.0.0",
+ org.aopalliance.aop;version="1.0.0",
+ org.aopalliance.intercept;version="1.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.1.2</version>
+		<version>0.1.4</version>
 	</parent>
 	<groupId>tools.mdsd.characteristics</groupId>
 	<artifactId>parent</artifactId>	
@@ -23,5 +23,4 @@
 		<module>features</module>
 		<module>releng</module>
 	</modules>
-	
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.1.4</version>
+		<version>0.2.0</version>
 	</parent>
 	<groupId>tools.mdsd.characteristics</groupId>
 	<artifactId>parent</artifactId>	

--- a/releng/tools.mdsd.characteristics.targetplatform/tp.target
+++ b/releng/tools.mdsd.characteristics.targetplatform/tp.target
@@ -2,18 +2,9 @@
 <?pde version="3.8"?><target name="tools.mdsd.characteristics Target Platform" sequenceNumber="1">
 <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" refresh="true">
-        <repository location="http://download.eclipse.org/releases/photon/201806271001"/>
-        <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+        <repository location="https://download.eclipse.org/releases/2019-03/201903201000/"/>
         <unit id="org.eclipse.core.runtime.feature.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.ocl.examples.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/ecoreworkflow/nightly/"/>
-        <unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.0.0"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-        <repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/ecoreworkflow/release/latest/"/>
-        <unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.0.0"/>
     </location>
 	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
         <repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/metamodel/modeling/foundations/nightly/"/>

--- a/releng/tools.mdsd.characteristics.targetplatform/tp.target
+++ b/releng/tools.mdsd.characteristics.targetplatform/tp.target
@@ -6,7 +6,11 @@
         <unit id="org.eclipse.core.runtime.feature.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.ocl.examples.feature.group" version="0.0.0"/>
     </location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" refresh="true">
+        <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20190226160451/repository"/>
+        <unit id="org.aopalliance" version="0.0.0"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
         <repository location="https://sdqweb.ipd.kit.edu/eclipse/mdsdtools/metamodel/modeling/foundations/nightly/"/>
         <unit id="tools.mdsd.modelingfoundations.identifier.feature.feature.group" version="0.0.0"/>
 		<unit id="tools.mdsd.modelingfoundations.identifier.ui.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
The default mdsd.tools target platform currently is Photon-0. Proper Java 11 support was introduced with 2019-03. Hence, this PR currently depends on the release of the updated parent pom to maven central MDSD-Tools/Maven-Build-Parents#11.